### PR TITLE
Adding MaterialTools.java and fixing a typo.

### DIFF
--- a/src/io/github/thebusybiscuit/cscorelib2/materials/MaterialCollections.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/materials/MaterialCollections.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 
 /**
  * This utility class can be used to get {@link Material} Arrays of some Material groups.
- * Mainly seperated by the class {@link Tag}
+ * Mainly separated by the class {@link Tag}
  * 
  * @author TheBusyBiscuit
  *

--- a/src/io/github/thebusybiscuit/cscorelib2/materials/MaterialTools.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/materials/MaterialTools.java
@@ -1,17 +1,17 @@
 package io.github.thebusybiscuit.cscorelib2.materials;
 
-import lombok.Getter;
-import org.bukkit.Material;
-import org.bukkit.Tag;
-
 import java.util.HashSet;
 import java.util.Set;
 
+import org.bukkit.Material;
+import org.bukkit.Tag;
+
+import lombok.Getter;
+
 /**
  * This utility class can be used to get {@link Material} Arrays that a tool is best at.
- * Mainly separated by the class {@link Tag}
  *
- * @author TheBusyBiscuit
+ * @author LinoxGH/ajan_12
  *
  */
 public final class MaterialTools {

--- a/src/io/github/thebusybiscuit/cscorelib2/materials/MaterialTools.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/materials/MaterialTools.java
@@ -1,0 +1,40 @@
+package io.github.thebusybiscuit.cscorelib2.materials;
+
+import lombok.Getter;
+import org.bukkit.Material;
+import org.bukkit.Tag;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * This utility class can be used to get {@link Material} Arrays that a tool is best at.
+ * Mainly separated by the class {@link Tag}
+ *
+ * @author TheBusyBiscuit
+ *
+ */
+public final class MaterialTools {
+
+    // This is a pure Utility class, we do not want any instantiation to happen!
+    private MaterialTools() {}
+
+    @Getter
+    private static final Material[]
+            shovelItems
+    ;
+
+    static {
+        Set<Material> shovel = new HashSet<>();
+
+        for (Material mat: Material.values()) {
+            if (Tag.DIRT_LIKE.isTagged(mat) || Tag.SAND.isTagged(mat)) shovel.add(mat);
+            // Checking for the materials not included in tags.
+            if (mat.name().contains("SNOW") || mat == Material.FARMLAND || mat == Material.SOUL_SAND ||
+                    mat == Material.CLAY || mat == Material.GRAVEL || mat == Material.GRASS_PATH) shovel.add(mat);
+        }
+
+        shovelItems = shovel.toArray(new Material[0]);
+    }
+
+}


### PR DESCRIPTION
MaterialTools is a Utility class used to get the preferred blocks for tools.