### PR TITLE
Improved default handling of Flags in BentoBox Protection

### DIFF
--- a/src/io/github/thebusybiscuit/cscorelib2/protection/modules/BentoBoxProtectionModule.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/protection/modules/BentoBoxProtectionModule.java
@@ -26,7 +26,8 @@ public class BentoBoxProtectionModule implements ProtectionModule {
 	@Override
 	public boolean hasPermission(OfflinePlayer p, Location l, Action action) {
 		Optional<Island> island = manager.getIslandAt(l);
-        return island.map(value -> value.isAllowed(User.getInstance(p), convert(action, l.getWorld()))).orElse(false);
+		Flag flag = convert(action, l.getWorld());
+		return island.map(value -> value.isAllowed(User.getInstance(p), flag)).orElse(flag.isSetForWorld(l.getWorld()));
 	}
 	
 	private Flag convert(Action action, World world) {


### PR DESCRIPTION
Might contribute to fix https://github.com/BentoBoxWorld/BentoBox/issues/773.
Suggested by @tastybento in the following comment: https://github.com/BentoBoxWorld/BentoBox/issues/773#issuecomment-506917465.

Instead of considering the default value to be 'false', it now checks the default value for the world the interaction takes place in. If said world is not one of BentoBox's worlds, 'false' will still be returned.