### PR TITLE
Add PersistentDataAPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.thebusybiscuit</groupId>
     <artifactId>CSCoreLib2</artifactId>
-    <version>0.4.5</version>
+    <version>0.5</version>
     
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.thebusybiscuit</groupId>
     <artifactId>CSCoreLib2</artifactId>
-    <version>0.4.2</version>
+    <version>0.4.3</version>
     
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.thebusybiscuit</groupId>
     <artifactId>CSCoreLib2</artifactId>
-    <version>0.4.3</version>
+    <version>0.4.5</version>
     
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/io/github/thebusybiscuit/cscorelib2/config/Config.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/config/Config.java
@@ -275,6 +275,8 @@ public class Config {
 	
 	/**
 	 * Recreates the File of this Config
+	 *
+	 * @return Returns if the file was successfully created
 	 */ 
 	public boolean createFile() {
 		try {
@@ -403,6 +405,7 @@ public class Config {
 	 * Gets the Contents of an Inventory at the specified Path
 	 *
 	 * @param  path The path in the Config File
+	 * @param title The title of the inventory, this can accept &amp; for color codes.
 	 * @return      The generated Inventory
 	 */ 
 	public Inventory getInventory(String path, String title) {

--- a/src/io/github/thebusybiscuit/cscorelib2/config/Localization.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/config/Localization.java
@@ -114,6 +114,7 @@ public class Localization {
 	 *
 	 * @param  key The Key of those Message
 	 * @param  message The Message which this key will refer to by default
+	 * @return The message set
 	 */ 
 	public String setDefaultMessage(String key, String message) {
 		String msg = getMessage(message);

--- a/src/io/github/thebusybiscuit/cscorelib2/config/Localization.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/config/Localization.java
@@ -114,7 +114,7 @@ public class Localization {
 	 *
 	 * @param  key The Key of those Message
 	 * @param  message The Message which this key will refer to by default
-	 * @return The messaged previously assigned, if none was set then the message passed.
+	 * @return The message previously assigned, if none was set then the message passed.
 	 */ 
 	public String setDefaultMessage(String key, String message) {
 		String msg = getMessage(message);

--- a/src/io/github/thebusybiscuit/cscorelib2/config/Localization.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/config/Localization.java
@@ -114,7 +114,7 @@ public class Localization {
 	 *
 	 * @param  key The Key of those Message
 	 * @param  message The Message which this key will refer to by default
-	 * @return The message set
+	 * @return The messaged previously assigned, if none was set then the message passed.
 	 */ 
 	public String setDefaultMessage(String key, String message) {
 		String msg = getMessage(message);

--- a/src/io/github/thebusybiscuit/cscorelib2/data/PersistentDataAPI.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/data/PersistentDataAPI.java
@@ -229,6 +229,8 @@ public class PersistentDataAPI {
      *            The {@link PersistentDataHolder} to retrieve the data from
      * @param key
      *            The key of the data to retrieve
+     * @param defaultVal
+     *            The default value to use if no key is found
      * @return The byte associated with this key or the default value if it doesn't exist
      */
     public static byte getByte(PersistentDataHolder holder, NamespacedKey key, byte defaultVal) {
@@ -255,6 +257,8 @@ public class PersistentDataAPI {
      *            The {@link PersistentDataHolder} to retrieve the data from
      * @param key
      *            The key of the data to retrieve
+     * @param defaultVal
+     *            The default value to use if no key is found
      * @return The short associated with this key or the default value if it doesn't exist
      */
     public static short getShort(PersistentDataHolder holder, NamespacedKey key, short defaultVal) {
@@ -281,6 +285,8 @@ public class PersistentDataAPI {
      *            The {@link PersistentDataHolder} to retrieve the data from
      * @param key
      *            The key of the data to retrieve
+     * @param defaultVal
+     *            The default value to use if no key is found
      * @return The integer associated with this key or the default value if it doesn't exist
      */
     public static int getInt(PersistentDataHolder holder, NamespacedKey key, int defaultVal) {
@@ -307,6 +313,8 @@ public class PersistentDataAPI {
      *            The {@link PersistentDataHolder} to retrieve the data from
      * @param key
      *            The key of the data to retrieve
+     * @param defaultVal
+     *            The default value to use if no key is found
      * @return The long associated with this key or the default value if it doesn't exist
      */
     public static long getLong(PersistentDataHolder holder, NamespacedKey key, long defaultVal) {
@@ -333,6 +341,10 @@ public class PersistentDataAPI {
      *            The {@link PersistentDataHolder} to retrieve the data from
      * @param key
      *            The key of the data to retrieve
+     * @param defaultVal
+     *            The default value to use if no key is found
+     * @param defaultVal
+     *            The default value to use if no key is found
      * @return The float associated with this key or the default value if it doesn't exist
      */
     public static float getFloat(PersistentDataHolder holder, NamespacedKey key, float defaultVal) {
@@ -359,6 +371,8 @@ public class PersistentDataAPI {
      *            The {@link PersistentDataHolder} to retrieve the data from
      * @param key
      *            The key of the data to retrieve
+     * @param defaultVal
+     *            The default value to use if no key is found
      * @return The double associated with this key or the default value if it doesn't exist
      */
     public static double getDouble(PersistentDataHolder holder, NamespacedKey key, double defaultVal) {
@@ -385,6 +399,8 @@ public class PersistentDataAPI {
      *            The {@link PersistentDataHolder} to retrieve the data from
      * @param key
      *            The key of the data to retrieve
+     * @param defaultVal
+     *            The default value to use if no key is found
      * @return The String associated with this key or the default value if it doesn't exist
      */
     public static String getString(PersistentDataHolder holder, NamespacedKey key, String defaultVal) {
@@ -411,6 +427,8 @@ public class PersistentDataAPI {
      *            The {@link PersistentDataHolder} to retrieve the data from
      * @param key
      *            The key of the data to retrieve
+     * @param defaultVal
+     *            The default value to use if no key is found
      * @return The byte array associated with this key or the default value if it doesn't exist
      */
     public static byte[] getByteArray(PersistentDataHolder holder, NamespacedKey key, byte[] defaultVal) {
@@ -437,6 +455,8 @@ public class PersistentDataAPI {
      *            The {@link PersistentDataHolder} to retrieve the data from
      * @param key
      *            The key of the data to retrieve
+     * @param defaultVal
+     *            The default value to use if no key is found
      * @return The byte associated with this key or the default value if it doesn't exist
      */
     public static int[] getIntArray(PersistentDataHolder holder, NamespacedKey key, int[] defaultVal) {
@@ -463,6 +483,8 @@ public class PersistentDataAPI {
      *            The {@link PersistentDataHolder} to retrieve the data from
      * @param key
      *            The key of the data to retrieve
+     * @param defaultVal
+     *            The default value to use if no key is found
      * @return The long array associated with this key or the default value if it doesn't exist
      */
     public static long[] getLongArray(PersistentDataHolder holder, NamespacedKey key, long[] defaultVal) {
@@ -489,9 +511,11 @@ public class PersistentDataAPI {
      *            The {@link PersistentDataHolder} to retrieve the data from
      * @param key
      *            The key of the data to retrieve
+     * @param defaultVal
+     *            The default value to use if no key is found
      * @return The byte associated with this key or the default value if it doesn't exist
      */
-    public static PersistentDataContainer getByteArray(PersistentDataHolder holder, NamespacedKey key,
+    public static PersistentDataContainer getContainer(PersistentDataHolder holder, NamespacedKey key,
                                                        PersistentDataContainer defaultVal) {
         return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.TAG_CONTAINER, defaultVal);
     }

--- a/src/io/github/thebusybiscuit/cscorelib2/data/PersistentDataAPI.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/data/PersistentDataAPI.java
@@ -1,0 +1,498 @@
+package io.github.thebusybiscuit.cscorelib2.data;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataHolder;
+import org.bukkit.persistence.PersistentDataType;
+
+public class PersistentDataAPI {
+
+    private PersistentDataAPI() {
+    }
+
+    /////////////////////////////////////
+    // Setters
+    /////////////////////////////////////
+    public static void setByte(PersistentDataHolder holder, NamespacedKey key, byte value) {
+        holder.getPersistentDataContainer().set(key, PersistentDataType.BYTE, value);
+    }
+
+    public static void setShort(PersistentDataHolder holder, NamespacedKey key, short value) {
+        holder.getPersistentDataContainer().set(key, PersistentDataType.SHORT, value);
+    }
+
+    public static void setInt(PersistentDataHolder holder, NamespacedKey key, int value) {
+        holder.getPersistentDataContainer().set(key, PersistentDataType.INTEGER, value);
+    }
+
+    public static void setLong(PersistentDataHolder holder, NamespacedKey key, long value) {
+        holder.getPersistentDataContainer().set(key, PersistentDataType.LONG, value);
+    }
+
+    public static void setFloat(PersistentDataHolder holder, NamespacedKey key, float value) {
+        holder.getPersistentDataContainer().set(key, PersistentDataType.FLOAT, value);
+    }
+
+    public static void setDouble(PersistentDataHolder holder, NamespacedKey key, double value) {
+        holder.getPersistentDataContainer().set(key, PersistentDataType.DOUBLE, value);
+    }
+
+    public static void setString(PersistentDataHolder holder, NamespacedKey key, String value) {
+        holder.getPersistentDataContainer().set(key, PersistentDataType.STRING, value);
+    }
+
+    public static void setByteArray(PersistentDataHolder holder, NamespacedKey key, byte[] value) {
+        holder.getPersistentDataContainer().set(key, PersistentDataType.BYTE_ARRAY, value);
+    }
+
+    public static void setIntArray(PersistentDataHolder holder, NamespacedKey key, int[] value) {
+        holder.getPersistentDataContainer().set(key, PersistentDataType.INTEGER_ARRAY, value);
+    }
+
+    public static void setLongArray(PersistentDataHolder holder, NamespacedKey key, long[] value) {
+        holder.getPersistentDataContainer().set(key, PersistentDataType.LONG_ARRAY, value);
+    }
+
+    public static void setContainer(PersistentDataHolder holder, NamespacedKey key, PersistentDataContainer value) {
+        holder.getPersistentDataContainer().set(key, PersistentDataType.TAG_CONTAINER, value);
+    }
+
+    /////////////////////////////////////
+    // Has
+    /////////////////////////////////////
+
+    /**
+     * Checks if the specified {@link PersistentDataHolder} has a byte with the specified key.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to check
+     * @param key
+     *            The key to check for
+     * @return {@code true} if the holder has a byte with the specified key.
+     */
+    public static boolean hasByte(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().has(key, PersistentDataType.BYTE);
+    }
+
+    /**
+     * Checks if the specified {@link PersistentDataHolder} has a short with the specified key.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to check
+     * @param key
+     *            The key to check for
+     * @return {@code true} if the holder has a short with the specified key.
+     */
+    public static boolean hasShort(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().has(key, PersistentDataType.SHORT);
+    }
+
+    /**
+     * Checks if the specified {@link PersistentDataHolder} has an integer with the specified key.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to check
+     * @param key
+     *            The key to check for
+     * @return {@code true} if the holder has an integer with the specified key.
+     */
+    public static boolean hasInt(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().has(key, PersistentDataType.INTEGER);
+    }
+
+    /**
+     * Checks if the specified {@link PersistentDataHolder} has a long with the specified key.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to check
+     * @param key
+     *            The key to check for
+     * @return {@code true} if the holder has a long with the specified key.
+     */
+    public static boolean hasLong(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().has(key, PersistentDataType.LONG);
+    }
+
+    /**
+     * Checks if the specified {@link PersistentDataHolder} has a float with the specified key.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to check
+     * @param key
+     *            The key to check for
+     * @return {@code true} if the holder has a float with the specified key.
+     */
+    public static boolean hasFloat(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().has(key, PersistentDataType.FLOAT);
+    }
+
+    /**
+     * Checks if the specified {@link PersistentDataHolder} has a double with the specified key.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to check
+     * @param key
+     *            The key to check for
+     * @return {@code true} if the holder has a double with the specified key.
+     */
+    public static boolean hasDouble(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().has(key, PersistentDataType.DOUBLE);
+    }
+
+    /**
+     * Checks if the specified {@link PersistentDataHolder} has a String with the specified key.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to check
+     * @param key
+     *            The key to check for
+     * @return {@code true} if the holder has a String with the specified key.
+     */
+    public static boolean hasString(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().has(key, PersistentDataType.STRING);
+    }
+
+    /**
+     * Checks if the specified {@link PersistentDataHolder} has a byte array with the specified key.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to check
+     * @param key
+     *            The key to check for
+     * @return {@code true} if the holder has a byte array with the specified key.
+     */
+    public static boolean hasByteArray(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().has(key, PersistentDataType.BYTE_ARRAY);
+    }
+
+    /**
+     * Checks if the specified {@link PersistentDataHolder} has an integer array with the specified key.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to check
+     * @param key
+     *            The key to check for
+     * @return {@code true} if the holder has an integer array with the specified key.
+     */
+    public static boolean hasIntArray(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().has(key, PersistentDataType.INTEGER_ARRAY);
+    }
+
+    /**
+     * Checks if the specified {@link PersistentDataHolder} has a long array with the specified key.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to check
+     * @param key
+     *            The key to check for
+     * @return {@code true} if the holder has a long array with the specified key.
+     */
+    public static boolean hasLongArray(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().has(key, PersistentDataType.LONG_ARRAY);
+    }
+
+    /**
+     * Checks if the specified {@link PersistentDataHolder} has a {@link PersistentDataContainer} with the specified
+     * key.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to check
+     * @param key
+     *            The key to check for
+     * @return {@code true} if the holder has a {@link PersistentDataContainer} with the specified key.
+     */
+    public static boolean hasContainer(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().has(key, PersistentDataType.TAG_CONTAINER);
+    }
+
+    /////////////////////////////////////
+    // Getters
+    /////////////////////////////////////
+
+    /**
+     * Get a byte value in a {@link PersistentDataContainer}, if the key doesn't exist it returns -1.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The byte associated with this key or -1 if it doesn't exist
+     */
+    public static byte getByte(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.BYTE, (byte) -1);
+    }
+
+    /**
+     * Get a byte value in a {@link PersistentDataContainer} or the default value passed if no key exists.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The byte associated with this key or the default value if it doesn't exist
+     */
+    public static byte getByte(PersistentDataHolder holder, NamespacedKey key, byte defaultVal) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.BYTE, defaultVal);
+    }
+
+    /**
+     * Get a short value in a {@link PersistentDataContainer}, if the key doesn't exist it returns -1.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The short associated with this key or -1 if it doesn't exist
+     */
+    public static short getShort(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.SHORT, (short) -1);
+    }
+
+    /**
+     * Get a short value in a {@link PersistentDataContainer} or the default value passed if no key exists.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The short associated with this key or the default value if it doesn't exist
+     */
+    public static short getShort(PersistentDataHolder holder, NamespacedKey key, short defaultVal) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.SHORT, defaultVal);
+    }
+
+    /**
+     * Get an integer value in a {@link PersistentDataContainer}, if the key doesn't exist it returns -1.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The integer associated with this key or -1 if it doesn't exist
+     */
+    public static int getInt(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.INTEGER, -1);
+    }
+
+    /**
+     * Get an integer value in a {@link PersistentDataContainer} or the default value passed if no key exists.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The integer associated with this key or the default value if it doesn't exist
+     */
+    public static int getInt(PersistentDataHolder holder, NamespacedKey key, int defaultVal) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.INTEGER, defaultVal);
+    }
+
+    /**
+     * Get a long value in a {@link PersistentDataContainer}, if the key doesn't exist it returns -1.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The long associated with this key or -1 if it doesn't exist
+     */
+    public static long getLong(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.LONG, (long) -1);
+    }
+
+    /**
+     * Get a long value in a {@link PersistentDataContainer} or the default value passed if no key exists.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The long associated with this key or the default value if it doesn't exist
+     */
+    public static long getLong(PersistentDataHolder holder, NamespacedKey key, long defaultVal) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.LONG, defaultVal);
+    }
+
+    /**
+     * Get a float value in a {@link PersistentDataContainer}, if the key doesn't exist it returns -1.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The float associated with this key or -1 if it doesn't exist
+     */
+    public static float getFloat(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.FLOAT, (float) -1);
+    }
+
+    /**
+     * Get a float value in a {@link PersistentDataContainer} or the default value passed if no key exists.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The float associated with this key or the default value if it doesn't exist
+     */
+    public static float getFloat(PersistentDataHolder holder, NamespacedKey key, float defaultVal) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.FLOAT, defaultVal);
+    }
+
+    /**
+     * Get a double value in a {@link PersistentDataContainer}, if the key doesn't exist it returns -1.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The double associated with this key or -1 if it doesn't exist
+     */
+    public static double getDouble(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.DOUBLE, (double) -1);
+    }
+
+    /**
+     * Get a double value in a {@link PersistentDataContainer} or the default value passed if no key exists.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The double associated with this key or the default value if it doesn't exist
+     */
+    public static double getDouble(PersistentDataHolder holder, NamespacedKey key, double defaultVal) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.DOUBLE, defaultVal);
+    }
+
+    /**
+     * Get a String value in a {@link PersistentDataContainer}, if the key doesn't exist it returns null.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The String associated with this key or null if it doesn't exist
+     */
+    public static String getString(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().get(key, PersistentDataType.STRING);
+    }
+
+    /**
+     * Get a String value in a {@link PersistentDataContainer} or the default value passed if no key exists.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The String associated with this key or the default value if it doesn't exist
+     */
+    public static String getString(PersistentDataHolder holder, NamespacedKey key, String defaultVal) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.STRING, defaultVal);
+    }
+
+    /**
+     * Get a byte array in a {@link PersistentDataContainer}, if the key doesn't exist it returns null.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The byte array associated with this key or null if it doesn't exist
+     */
+    public static byte[] getByteArray(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().get(key, PersistentDataType.BYTE_ARRAY);
+    }
+
+    /**
+     * Get a byte array in a {@link PersistentDataContainer} or the default value passed if no key exists.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The byte array associated with this key or the default value if it doesn't exist
+     */
+    public static byte[] getByteArray(PersistentDataHolder holder, NamespacedKey key, byte[] defaultVal) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.BYTE_ARRAY, defaultVal);
+    }
+
+    /**
+     * Get a integer array in a {@link PersistentDataContainer}, if the key doesn't exist it returns null.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The integer array associated with this key or null if it doesn't exist
+     */
+    public static int[] getIntArray(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().get(key, PersistentDataType.INTEGER_ARRAY);
+    }
+
+    /**
+     * Get a byte array in a {@link PersistentDataContainer} or the default value passed if no key exists.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The byte associated with this key or the default value if it doesn't exist
+     */
+    public static int[] getIntArray(PersistentDataHolder holder, NamespacedKey key, int[] defaultVal) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.INTEGER_ARRAY, defaultVal);
+    }
+
+    /**
+     * Get a long array in a {@link PersistentDataContainer}, if the key doesn't exist it returns null.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The long array associated with this key or null if it doesn't exist
+     */
+    public static long[] getLongArray(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().get(key, PersistentDataType.LONG_ARRAY);
+    }
+
+    /**
+     * Get a long array in a {@link PersistentDataContainer} or the default value passed if no key exists.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The long array associated with this key or the default value if it doesn't exist
+     */
+    public static long[] getLongArray(PersistentDataHolder holder, NamespacedKey key, long[] defaultVal) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.LONG_ARRAY, defaultVal);
+    }
+
+    /**
+     * Get a nested {@link PersistentDataContainer}, if the key doesn't exist it returns null.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The byte associated with this key or null if it doesn't exist
+     */
+    public static PersistentDataContainer getContainer(PersistentDataHolder holder, NamespacedKey key) {
+        return holder.getPersistentDataContainer().get(key, PersistentDataType.TAG_CONTAINER);
+    }
+
+    /**
+     * Get a nested {@link PersistentDataContainer} or the default value passed if no key exists.
+     *
+     * @param holder
+     *            The {@link PersistentDataHolder} to retrieve the data from
+     * @param key
+     *            The key of the data to retrieve
+     * @return The byte associated with this key or the default value if it doesn't exist
+     */
+    public static PersistentDataContainer getByteArray(PersistentDataHolder holder, NamespacedKey key,
+                                                       PersistentDataContainer defaultVal) {
+        return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.TAG_CONTAINER, defaultVal);
+    }
+}

--- a/src/io/github/thebusybiscuit/cscorelib2/data/PersistentDataAPI.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/data/PersistentDataAPI.java
@@ -41,15 +41,15 @@ public class PersistentDataAPI {
         holder.getPersistentDataContainer().set(key, PersistentDataType.STRING, value);
     }
 
-    public static void setByteArray(PersistentDataHolder holder, NamespacedKey key, byte[] value) {
+    public static void setByteArray(PersistentDataHolder holder, NamespacedKey key, byte... value) {
         holder.getPersistentDataContainer().set(key, PersistentDataType.BYTE_ARRAY, value);
     }
 
-    public static void setIntArray(PersistentDataHolder holder, NamespacedKey key, int[] value) {
+    public static void setIntArray(PersistentDataHolder holder, NamespacedKey key, int... value) {
         holder.getPersistentDataContainer().set(key, PersistentDataType.INTEGER_ARRAY, value);
     }
 
-    public static void setLongArray(PersistentDataHolder holder, NamespacedKey key, long[] value) {
+    public static void setLongArray(PersistentDataHolder holder, NamespacedKey key, long... value) {
         holder.getPersistentDataContainer().set(key, PersistentDataType.LONG_ARRAY, value);
     }
 

--- a/src/io/github/thebusybiscuit/cscorelib2/data/PersistentDataAPI.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/data/PersistentDataAPI.java
@@ -431,7 +431,7 @@ public class PersistentDataAPI {
      *            The default value to use if no key is found
      * @return The byte array associated with this key or the default value if it doesn't exist
      */
-    public static byte[] getByteArray(PersistentDataHolder holder, NamespacedKey key, byte[] defaultVal) {
+    public static byte[] getByteArray(PersistentDataHolder holder, NamespacedKey key, byte... defaultVal) {
         return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.BYTE_ARRAY, defaultVal);
     }
 
@@ -459,7 +459,7 @@ public class PersistentDataAPI {
      *            The default value to use if no key is found
      * @return The byte associated with this key or the default value if it doesn't exist
      */
-    public static int[] getIntArray(PersistentDataHolder holder, NamespacedKey key, int[] defaultVal) {
+    public static int[] getIntArray(PersistentDataHolder holder, NamespacedKey key, int... defaultVal) {
         return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.INTEGER_ARRAY, defaultVal);
     }
 
@@ -487,7 +487,7 @@ public class PersistentDataAPI {
      *            The default value to use if no key is found
      * @return The long array associated with this key or the default value if it doesn't exist
      */
-    public static long[] getLongArray(PersistentDataHolder holder, NamespacedKey key, long[] defaultVal) {
+    public static long[] getLongArray(PersistentDataHolder holder, NamespacedKey key, long... defaultVal) {
         return holder.getPersistentDataContainer().getOrDefault(key, PersistentDataType.LONG_ARRAY, defaultVal);
     }
 

--- a/src/io/github/thebusybiscuit/cscorelib2/inventory/ChestMenu.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/inventory/ChestMenu.java
@@ -60,6 +60,7 @@ public class ChestMenu implements Cloneable, Iterable<ItemStack> {
 	 * Creates a new ChestMenu with the specified
 	 * Title and a {@link Runnable} for dirty-marking
 	 *
+	 * @param  plugin The referencing plugin
 	 * @param  title The title of the Menu
 	 * @param  dirtyRunnable A {@link Runnable} that is run when the Inventory was modified
 	 */ 
@@ -83,7 +84,8 @@ public class ChestMenu implements Cloneable, Iterable<ItemStack> {
 
 	/**
 	 * Creates a new ChestMenu with a specified Title
-	 * 
+	 *
+	 * @param plugin The referencing plugin
 	 * @param title The title of this Menu
 	 */
 	public ChestMenu(Plugin plugin, String title) {
@@ -121,7 +123,7 @@ public class ChestMenu implements Cloneable, Iterable<ItemStack> {
 	 * This method forbids Items that pass the Test from Insertion into this Inventory.
 	 * If the Predicate returns true, the Item cannot be inserted.
 	 * 
-	 * @param predicate A Predicate<ItemStack>
+	 * @param predicate An {@link ItemStack} {@link Predicate}
 	 */
 	public void preventItems(Predicate<ItemStack> predicate) {
 		this.predicate = predicate;
@@ -171,7 +173,7 @@ public class ChestMenu implements Cloneable, Iterable<ItemStack> {
 	 * clickable while viewing this Menu
 	 *
 	 * @return      Whether the empty menu slots are clickable
-	 */ 
+	 */
 	public boolean areEmptySlotsClickable() {
 		return emptyClickable;
 	}
@@ -313,6 +315,8 @@ public class ChestMenu implements Cloneable, Iterable<ItemStack> {
 	
 	/**
 	 * Resets this ChestMenu to a Point BEFORE the User interacted with it
+	 *
+	 * @param update Update current inv
 	 */ 
 	public void reset(boolean update) {
 		if (update) inv.clear();
@@ -425,8 +429,8 @@ public class ChestMenu implements Cloneable, Iterable<ItemStack> {
 	 * if you specify a bigger amount than present, it will simply set the Item to null.
 	 * 
 	 * If replaceConsumables is true, the following things will not be replaced with 'null':
-	 * Buckets -> new ItemStack(Material.BUCKET)
-	 * Potions -> new ItemStack(Material.GLASS_BOTTLE)
+	 * {@code Buckets -> new ItemStack(Material.BUCKET)}
+	 * {@code Potions -> new ItemStack(Material.GLASS_BOTTLE)}
 	 * 
 	 * @param slot					The Slot in which to remove the Item
 	 * @param amount				How many Items should be removed

--- a/src/io/github/thebusybiscuit/cscorelib2/inventory/InvUtils.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/inventory/InvUtils.java
@@ -47,8 +47,8 @@ public final class InvUtils {
 	 * if you specify a bigger amount than present, it will simply set the Item to null.
 	 * 
 	 * If replaceConsumables is true, the following things will not be replaced with 'null':
-	 * Buckets -> new ItemStack(Material.BUCKET)
-	 * Potions -> new ItemStack(Material.GLASS_BOTTLE)
+	 * {@code Buckets -> new ItemStack(Material.BUCKET)}
+	 * {@code Potions -> new ItemStack(Material.GLASS_BOTTLE)}
 	 * 
 	 * @param inv					The Inventory to check
 	 * @param slot					The Slot in which to remove the Item
@@ -79,7 +79,8 @@ public final class InvUtils {
 	 * Note that this also checks {@link ItemStack#getAmount()}
 	 * 
 	 * If you do not specify any Slots, all Slots of the Inventory will be checked.
-	 * 
+	 *
+	 * @param inv		The inventory to check
 	 * @param item		The Item that shall be tested for
 	 * @param slots		The Slots that shall be iterated over
 	 * @return			Whether the slots have space for the {@link ItemStack}

--- a/src/io/github/thebusybiscuit/cscorelib2/math/DoubleHandler.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/math/DoubleHandler.java
@@ -8,10 +8,10 @@ public final class DoubleHandler {
 	
 	/**
 	 * This method returns a very fancy representation of Doubles.
-	 * 
-	 * 1000 		-> 1K
-	 * 32000		-> 32K
-	 * 232 000 000	-> 2.32M
+	 *
+	 * {@code 1000 		-> 1K}
+	 * {@code 32000		-&gt; 32K}
+	 * {@code 232 000 000	-&gt; 2.32M}
 	 * (and so on)
 	 * 
 	 * @param d	The double that should be formatted

--- a/src/io/github/thebusybiscuit/cscorelib2/reflection/ReflectionUtils.java
+++ b/src/io/github/thebusybiscuit/cscorelib2/reflection/ReflectionUtils.java
@@ -67,7 +67,7 @@ public final class ReflectionUtils {
 	 * @param  field The name of the Field you are looking for
 	 * @return      The found Field
 	 *
-	 * @throws Exception
+	 * @throws Exception If there's an issue getting a field
 	 */
 	public static Field getField(Class<?> c, String field) throws Exception {
 		return c.getDeclaredField(field);
@@ -76,10 +76,12 @@ public final class ReflectionUtils {
 	/**
 	 * Modifies a Field in an Object
 	 *
+	 * @param <T> The type of the specified field
 	 * @param  object The Object containing the Field
 	 * @param  c The Class in which we are looking for this field
 	 * @param  field The Name of that Field
 	 * @param  value The Value for that Field
+	 * @throws Exception If there was an issue setting a field value
 	 */
 	public static <T> void setFieldValue(T object, Class<?> c, String field, Object value) throws Exception {
 		Field f = getField(c, field);
@@ -90,9 +92,11 @@ public final class ReflectionUtils {
 	/**
 	 * Modifies a Field in an Object
 	 *
+	 * @param <T> The type of the specified field
 	 * @param  object The Object containing the Field
 	 * @param  field The Name of that Field
 	 * @param  value The Value for that Field
+	 * @throws Exception If there was an issue setting a field value
 	 */
 	public static <T> void setFieldValue(T object, String field, Object value) throws Exception {
 		Field f = getField(object.getClass(), field);
@@ -105,6 +109,7 @@ public final class ReflectionUtils {
 	 *
 	 * @param  object The Object containing the Field
 	 * @param  field The Name of that Field
+	 * @throws Exception If an issue occurred while getting the field value
 	 * @return      The Value of a Field
 	 */
 	public static Object getFieldValue(Object object, String field) throws Exception {
@@ -166,6 +171,7 @@ public final class ReflectionUtils {
 	 *
 	 * @param  name The Name of the Class your Inner class is located in
 	 * @param  subname The Name of the inner Class you are looking for
+	 * @throws Exception If there was an issue getting the specified inner class.
 	 * @return      The Class in your specified Class
 	 */
 	public static Class<?> getInnerNMSClass(String name, String subname) throws Exception {
@@ -176,6 +182,7 @@ public final class ReflectionUtils {
 	 * Returns an NMS Class via Reflection
 	 *
 	 * @param  name The Name of the Class you are looking for
+	 * @throws Exception If there was an issue getting the specified class
 	 * @return      The Class in that Package
 	 */
 	public static Class<?> getNMSClass(String name) throws Exception {
@@ -187,6 +194,7 @@ public final class ReflectionUtils {
 	 *
 	 * @param  name The Name of the Class your Inner class is located in
 	 * @param  subname The Name of the inner Class you are looking for
+	 * @throws Exception If there was an issue getting the specified inner class.
 	 * @return      The Class in your specified Class
 	 */
 	public static Class<?> getInnerOBCClass(String name, String subname) throws Exception {
@@ -197,6 +205,7 @@ public final class ReflectionUtils {
 	 * Returns an OBC Class via Reflection
 	 *
 	 * @param  name The Name of the Class you are looking for
+	 * @throws Exception If there was an issue getting the specified class.
 	 * @return      The Class in that Package
 	 */
 	public static Class<?> getOBCClass(String name) throws Exception {


### PR DESCRIPTION
## What is it?
This creates a very friendly way to set and access data of a PersistentDataHolder.

You can add these values to ItemMetas, TileEntities and any other Entity.

This could be used to easily identify items in the future by setting the item ID on any SF item, it can also be used on heads to identify what they are (Which can replace the current system and prevent a lot of issues there).

## How to use it
Example setterusage:
```java
ItemMeta im = is.getItemMeta();
DataAPI.setString(im, new NamespacedKey(CSCoreLib.getLib(), "example_key"), "EXAMPLE_ITEM");
is.setItemMeta(im);
```

Example getter:
```java
String itemKey = DataAPI.getString(im);
Item item = Items.getItemByKey(item);
if (item != null) {
  item.doWhatever();
}
```

You can also pass a default value to getters, like so:
```java
int uses = DataAPI.getInt(im, MAX_USES);
sender.sendMessage("You have " + uses + " left on that item");
```

I recommend having a constants class with the `NamespaceKey`s that will be used. 