### PR TITLE
Use blocklockers API to check permission

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/protection/modules/BlockLockerProtectionModule.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/protection/modules/BlockLockerProtectionModule.java
@@ -3,14 +3,10 @@ package io.github.thebusybiscuit.cscorelib2.protection.modules;
 import org.bukkit.Location;
 import org.bukkit.OfflinePlayer;
 
-import com.google.common.base.Optional;
-
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectableAction;
 import io.github.thebusybiscuit.cscorelib2.protection.ProtectionModule;
 import nl.rutgerkok.blocklocker.BlockLockerAPI;
 import nl.rutgerkok.blocklocker.BlockLockerPlugin;
-import nl.rutgerkok.blocklocker.profile.Profile;
-import nl.rutgerkok.blocklocker.protection.Protection;
 
 
 public class BlockLockerProtectionModule implements ProtectionModule {
@@ -30,17 +26,8 @@ public class BlockLockerProtectionModule implements ProtectionModule {
 	@Override
 	public boolean hasPermission(OfflinePlayer p, Location l, ProtectableAction action) {
 		if (!action.isBlockAction()) return true;
-		
-		Optional<Protection> protection = plugin.getProtectionFinder().findProtection(l.getBlock());
-		
-		if (protection.isPresent()) {
-			Profile profile = plugin.getProfileFactory().fromNameAndUniqueId(p.getName(), Optional.of(p.getUniqueId()));
-			return protection.get().isAllowed(profile);
-		}
-		else {
-			return true;
-		}
-		
+
+		return(BlockLockerAPI.isAllowed(p.getPlayer(), l.getBlock(), false));
 	}
 }
 	

--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/protection/modules/BlockLockerProtectionModule.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/protection/modules/BlockLockerProtectionModule.java
@@ -27,7 +27,7 @@ public class BlockLockerProtectionModule implements ProtectionModule {
 	public boolean hasPermission(OfflinePlayer p, Location l, ProtectableAction action) {
 		if (!action.isBlockAction()) return true;
 
-		return(BlockLockerAPI.isAllowed(p.getPlayer(), l.getBlock(), false));
+		return BlockLockerAPI.isAllowed(p.getPlayer(), l.getBlock(), false);
 	}
 }
 	


### PR DESCRIPTION
This PR makes CS-CoreLib2 compatible with old and new versions of blocklocker by using the API provided by the plugin, necessary as the most recent update breaks the existing method.