### PR TITLE
Update InvUtil's fit methods to check the Inventory's maxStackSize as well

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.thebusybiscuit</groupId>
     <artifactId>cscorelib2</artifactId>
 
-    <version>0.29.1</version>
+    <version>0.29.2</version>
 
     <packaging>jar</packaging>
     <url>https://github.com/TheBusyBiscuit/CS-CoreLib2</url>

--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/InvUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/InvUtils.java
@@ -45,7 +45,7 @@ public final class InvUtils {
      *            The Inventory these items are existing in
      * @return Whether the maxStackSizes allow for these items to stack
      */
-    private static boolean underMaxStackSize(@NonNull ItemStack stack, @NonNull ItemStack item, @NonNull Inventory inv) {
+    private static boolean isValidStackSize(@Nonnull ItemStack stack, @Nonnull ItemStack item, @Nonnull Inventory inv) {
         int newStackSize = stack.getAmount() + item.getAmount();
         return newStackSize <= stack.getMaxStackSize() && newStackSize <= inv.getMaxStackSize();
     }

--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/InvUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/InvUtils.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
+import javax.annotation.Nonnull;
+
 import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;

--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/InvUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/InvUtils.java
@@ -77,7 +77,7 @@ public final class InvUtils {
 
             if (stack == null || stack.getType() == Material.AIR) {
                 return true;
-            } else if (underMaxStackSize(stack, item, inv) && ItemUtils.canStack(stack, item)) {
+            } else if (isValidStackSize(stack, item, inv) && ItemUtils.canStack(stack, item)) {
                 return true;
             }
         }
@@ -123,7 +123,7 @@ public final class InvUtils {
                 if (stack == null || stack.getType() == Material.AIR) {
                     cache.put(slot, items[i]);
                     resolved = true;
-                } else if (underMaxStackSize(stack, item, inv) && ItemUtils.canStack(stack, item)) {
+                } else if (isValidStackSize(stack, item, inv) && ItemUtils.canStack(stack, item)) {
                     ItemStack clone = stack.clone();
                     clone.setAmount(stack.getAmount() + item.getAmount());
                     cache.put(slot, clone);

--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/InvUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/InvUtils.java
@@ -32,6 +32,25 @@ public final class InvUtils {
     }
 
     /**
+     * This method checks both an ItemStack's and an Inventory's maxStackSize to determine
+     * if a given ItemStack can stack with another ItemStack in the given Inventory
+     * 
+     * @author kii-chan-reloaded
+     *
+     * @param stack
+     *            The ItemStack already in the inventory
+     * @param item
+     *            The ItemStack that shall be tested for
+     * @param inv
+     *            The Inventory these items are existing in
+     * @return Whether the maxStackSizes allow for these items to stack
+     */
+    private static boolean underMaxStackSize(@NonNull ItemStack stack, @NonNull ItemStack item, @NonNull Inventory inv) {
+        int newStackSize = stack.getAmount() + item.getAmount();
+        return newStackSize <= stack.getMaxStackSize() && newStackSize <= inv.getMaxStackSize();
+    }
+
+    /**
      * This method checks if an Item can fit into the specified slots.
      * Note that this also checks {@link ItemStack#getAmount()}
      * 
@@ -56,7 +75,7 @@ public final class InvUtils {
 
             if (stack == null || stack.getType() == Material.AIR) {
                 return true;
-            } else if (stack.getAmount() + item.getAmount() <= stack.getMaxStackSize() && ItemUtils.canStack(stack, item)) {
+            } else if (underMaxStackSize(stack, item, inv) && ItemUtils.canStack(stack, item)) {
                 return true;
             }
         }
@@ -102,7 +121,7 @@ public final class InvUtils {
                 if (stack == null || stack.getType() == Material.AIR) {
                     cache.put(slot, items[i]);
                     resolved = true;
-                } else if (stack.getAmount() + item.getAmount() <= stack.getMaxStackSize() && ItemUtils.canStack(stack, item)) {
+                } else if (underMaxStackSize(stack, item, inv) && ItemUtils.canStack(stack, item)) {
                     ItemStack clone = stack.clone();
                     clone.setAmount(stack.getAmount() + item.getAmount());
                     cache.put(slot, clone);


### PR DESCRIPTION
Originally, InvUtil's fit methods only checked the maxStackSize of the ItemStack already in the Inventory. If an Inventory's maxStackSize was set with setMaxStackSize prior to calling a fit method, InvUtil would allow items to stack above that limit because it did not check for the Inventory's maxStackSize. This change takes both the inventory's maxStackSize and the existing ItemStack's maxStackSize into consideration when determining if an item fits in the inventory.