### PR TITLE
Add InvUtils updates to ChestMenu

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/ChestMenu.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/ChestMenu.java
@@ -507,7 +507,7 @@ public class ChestMenu implements Cloneable, Iterable<ItemStack> {
                 toInventory().setItem(slot, item);
                 markDirty();
                 return true;
-            } else if (stack.getAmount() + item.getAmount() <= stack.getMaxStackSize() && ItemUtils.canStack(stack, item)) {
+            } else if (InvUtils.isValidStackSize(stack, item, toInventory()) && ItemUtils.canStack(stack, item)) {
                 stack.setAmount(stack.getAmount() + item.getAmount());
                 toInventory().setItem(slot, stack);
                 markDirty();

--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/InvUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/InvUtils.java
@@ -5,8 +5,6 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
-import javax.annotation.Nonnull;
-
 import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -47,7 +45,7 @@ public final class InvUtils {
      *            The Inventory these items are existing in
      * @return Whether the maxStackSizes allow for these items to stack
      */
-    private static boolean isValidStackSize(@Nonnull ItemStack stack, @Nonnull ItemStack item, @Nonnull Inventory inv) {
+    public static boolean isValidStackSize(@NonNull ItemStack stack, @NonNull ItemStack item, @NonNull Inventory inv) {
         int newStackSize = stack.getAmount() + item.getAmount();
         return newStackSize <= stack.getMaxStackSize() && newStackSize <= inv.getMaxStackSize();
     }


### PR DESCRIPTION
Previously, InvUtils was updated to respect the Inventory's maxStackSize when checking for space. ChestMenu, however, used the same, patched-out code when it would put an item in the Inventory. This meant that although checking for free space did abide by the limits, ChestMenu still behaved as before and would stack the items regardless of the limits. This commit changes the limit-ignoring comparison to use the comparison method `isValidStackSize` in InvUtils, and makes that method public.

This was missed in the first pull request, my apologies.

For a concrete example, assume an AContainer has an Inventory with a maxStackSize of 1 and one item in its first output slot. The recipe check (with the previous changes) would correctly identify that the second output slot is open and begin processing the recipe. When the recipe finished processing, the BlockMenu (-> DirtyChestMenu -> ChestMenu) would attempt to add the item to inventory. Because it used the old comparison, it would still find the first output slot to be a valid output and add the recipe's output item to it despite the maxStackSize. If the AContainer produced the same recipe output every time, this would likely be fine since the items would stack in the player inventory anyway. However, if the AContainer outputs the same base item with varying metadata values that are not checked for by ItemStackWrapper, then the newly output item becomes a copy of the item in the first output slot when it is put in the Inventory instead of going in the open second slot as intended.

****

As I mentioned before, I only have a working knowledge of Java right now, so I haven't dove into the particulars on annotations quite yet. Since you mentioned the differences in `NonNull` versus `Nonnull` being due to the method being private, I reverted those back to `NonNull` for the public version; hopefully that was the right move. If you'd rather keep InvUtils as is, `putItem` could check with the public `fits` instead, however since there would be redundant code involved with doing that, I figured these changes would be the better option.