### PR TITLE
[WIP] Cache for protection lookups

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/collections/OptionalBoolean.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/collections/OptionalBoolean.java
@@ -1,0 +1,95 @@
+package io.github.thebusybiscuit.cscorelib2.collections;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.NoSuchElementException;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public final class OptionalBoolean {
+
+    private static final OptionalBoolean EMPTY = new OptionalBoolean();
+
+    private final boolean isPresent;
+    private final boolean value;
+
+    private OptionalBoolean() {
+        this.isPresent = false;
+        this.value = false;
+    }
+
+    private OptionalBoolean(boolean value) {
+        this.isPresent = true;
+        this.value = value;
+    }
+
+    @Nonnull
+    public static OptionalBoolean empty() {
+        return EMPTY;
+    }
+
+    @Nonnull
+    public static OptionalBoolean of(boolean value) {
+        return new OptionalBoolean(value);
+    }
+
+    public boolean getAsBoolean() {
+        if (!isPresent) {
+            throw new NoSuchElementException("No value present");
+        }
+        return value;
+    }
+
+    public boolean isPresent() {
+        return isPresent;
+    }
+
+    public void ifPresent(@Nonnull Consumer<Boolean> consumer) {
+        if (isPresent)
+            consumer.accept(value);
+    }
+
+    public boolean orElse(boolean other) {
+        return isPresent ? value : other;
+    }
+
+    public boolean orElseGet(@Nonnull BooleanSupplier other) {
+        return isPresent ? value : other.getAsBoolean();
+    }
+
+    public <X extends Throwable> boolean orElseThrow(@Nonnull Supplier<X> exceptionSupplier) throws X {
+        if (isPresent) {
+            return value;
+        } else {
+            throw exceptionSupplier.get();
+        }
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof OptionalBoolean)) {
+            return false;
+        }
+
+        OptionalBoolean other = (OptionalBoolean) obj;
+        return (isPresent && other.isPresent)
+            ? value == other.value
+            : isPresent == other.isPresent;
+    }
+
+    @Override
+    public int hashCode() {
+        return isPresent ? Boolean.hashCode(value) : 0;
+    }
+
+    @Nonnull
+    @Override
+    public String toString() {
+        return "OptionalBoolean{value=" + (isPresent ? "empty" : value) + '}';
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/protection/ProtectionCache.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/protection/ProtectionCache.java
@@ -1,0 +1,41 @@
+package io.github.thebusybiscuit.cscorelib2.protection;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.github.thebusybiscuit.cscorelib2.blocks.BlockPosition;
+import io.github.thebusybiscuit.cscorelib2.collections.OptionalBoolean;
+
+import javax.annotation.Nonnull;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+public class ProtectionCache {
+
+    private static final CacheBuilder<Object, Object> defaultBuilder = CacheBuilder.newBuilder()
+        .concurrencyLevel(1)
+        .expireAfterAccess(5, TimeUnit.MINUTES);
+
+    private final Cache<UUID, Cache<BlockPosition, Boolean>> permissionCache = defaultBuilder.build();
+
+    @Nonnull
+    public OptionalBoolean getCachedValue(@Nonnull UUID uuid, @Nonnull BlockPosition position) {
+        Cache<BlockPosition, Boolean> map = permissionCache.getIfPresent(uuid);
+        if (map != null && map.size() > 0) {
+            Boolean allowed = map.getIfPresent(position);
+
+            if (allowed != null) {
+                return OptionalBoolean.of(allowed);
+            }
+        }
+        return OptionalBoolean.empty();
+    }
+
+    public void storeValue(@Nonnull UUID uuid, @Nonnull BlockPosition position, boolean hasPermission) {
+        Cache<BlockPosition, Boolean> map = permissionCache.getIfPresent(uuid);
+        if (map == null) {
+            map = defaultBuilder.build();
+        }
+        map.put(position, hasPermission);
+        permissionCache.put(uuid, map);
+    }
+}

--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/protection/ProtectionManager.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/protection/ProtectionManager.java
@@ -201,6 +201,7 @@ public final class ProtectionManager {
         }
 
         permissionCache.storeValue(p.getUniqueId(), pos, hasPermission);
+        return hasPermission;
     }
 
     public void logAction(@NonNull OfflinePlayer p, @NonNull Block b, @NonNull ProtectableAction action) {


### PR DESCRIPTION
This implements a Guava Cache to the ProtectionManager. We have this so that we can cache what the permission is on a block for a player.

The overhead of this isn't too much as it will remove the entry if it isn't read for 5 mins (approx).

## Current Issues
There are a few things to work through first though:

* This is ugly, is there a better way to represent and save this data?
  * I am not a fan of using 2 caches here but what is the better way? A Map instead of the inner cache would mean the data is saved way more
* If a permission was changed after we cached it, what do we do?
  * We can change this to `expireAfterWrite` which would lessen the performance improvement but at least work.
  * If we changed to `expireAfterWrite` then there is (approx) 5 mins where a player could complain over the old cache

Definitely some feedback needed on this - @TheBusyBiscuit @md5sha256