### PR TITLE
1.17 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.thebusybiscuit</groupId>
     <artifactId>cscorelib2</artifactId>
 
-    <version>0.31.0</version>
+    <version>0.32.0_3</version>
 
     <packaging>jar</packaging>
     <url>https://github.com/TheBusyBiscuit/CS-CoreLib2</url>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.thebusybiscuit</groupId>
     <artifactId>cscorelib2</artifactId>
 
-    <version>0.32.0_3</version>
+    <version>0.32.0</version>
 
     <packaging>jar</packaging>
     <url>https://github.com/TheBusyBiscuit/CS-CoreLib2</url>

--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/ItemUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/inventory/ItemUtils.java
@@ -34,6 +34,10 @@ public final class ItemUtils {
         try {
             if (ReflectionUtils.isUnitTestEnvironment()) {
                 System.out.println("MockBukkit detected! Cannot access NMS ItemStack API.");
+            } else if (ReflectionUtils.getMajorVersion() >= 17) {
+                copy = ReflectionUtils.getOBCClass("inventory.CraftItemStack").getMethod("asNMSCopy", ItemStack.class);
+                getName = ReflectionUtils.getMethod(ReflectionUtils.getNetMinecraftClass("world.item.ItemStack"), "getName");
+                toString = ReflectionUtils.getMethod(ReflectionUtils.getNetMinecraftClass("network.chat.IChatBaseComponent"), "getString");
             } else {
                 copy = ReflectionUtils.getOBCClass("inventory.CraftItemStack").getMethod("asNMSCopy", ItemStack.class);
                 getName = ReflectionUtils.getMethod(ReflectionUtils.getNMSClass("ItemStack"), "getName");

--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/reflection/ReflectionUtils.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/reflection/ReflectionUtils.java
@@ -26,6 +26,7 @@ public final class ReflectionUtils {
 
     private ReflectionUtils() {}
 
+    private static int majorVersion;
     private static String currentVersion;
     private static final Map<Class<?>, Class<?>> primitiveTypes = new HashMap<>();
 
@@ -38,6 +39,11 @@ public final class ReflectionUtils {
         primitiveTypes.put(Float.class, Float.TYPE);
         primitiveTypes.put(Double.class, Double.TYPE);
         primitiveTypes.put(Boolean.class, Boolean.TYPE);
+
+        currentVersion =  Bukkit.getServer().getClass().getPackage().getName()
+            .substring(Bukkit.getServer().getClass().getPackage().getName().lastIndexOf('.') + 1);
+        // Turn v1_17_R1 -> 17
+        majorVersion = Integer.parseInt(currentVersion.replace("v1_", "").replace("_R1", ""));
     }
 
     /**
@@ -265,6 +271,17 @@ public final class ReflectionUtils {
     }
 
     /**
+     * Returns a `net.minecraft` class via Reflection.
+     *
+     * @param name The class name of which to fetch
+     * @return The `net.minecraft` class.
+     * @throws ClassNotFoundException If the class does not exist
+     */
+    public static Class<?> getNetMinecraftClass(@Nonnull String name) throws ClassNotFoundException {
+        return Class.forName("net.minecraft." + (majorVersion <= 16 ? getVersion() + '.' : "") + name);
+    }
+
+    /**
      * Returns an NMS Class via Reflection
      *
      * @param name
@@ -277,7 +294,7 @@ public final class ReflectionUtils {
      */
     @Nonnull
     public static Class<?> getNMSClass(@NonNull String name) throws ClassNotFoundException {
-        return Class.forName(new StringBuilder().append("net.minecraft.server.").append(getVersion()).append(".").append(name).toString());
+        return Class.forName("net.minecraft.server." + (majorVersion <= 16 ? getVersion() + '.' : "") + name);
     }
 
     /**
@@ -311,7 +328,7 @@ public final class ReflectionUtils {
      */
     @Nonnull
     public static Class<?> getOBCClass(@NonNull String name) throws ClassNotFoundException {
-        return Class.forName(new StringBuilder().append("org.bukkit.craftbukkit.").append(getVersion()).append(".").append(name).toString());
+        return Class.forName("org.bukkit.craftbukkit." + getVersion() + '.' + name);
     }
 
     /**
@@ -326,6 +343,13 @@ public final class ReflectionUtils {
         }
 
         return currentVersion;
+    }
+
+    /**
+     * Return the Minecraft Major Version (15, 16, 17).
+     */
+    public static int getMajorVersion() {
+        return majorVersion;
     }
 
     /**

--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/skull/SkullBlock.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/skull/SkullBlock.java
@@ -25,13 +25,25 @@ public final class SkullBlock {
 
     static {
         try {
-            handle = ReflectionUtils.getOBCClass("CraftWorld").getMethod("getHandle");
+            if (ReflectionUtils.getMajorVersion() >= 17) {
+                handle = ReflectionUtils.getOBCClass("CraftWorld").getMethod("getHandle");
 
-            setGameProfile = ReflectionUtils.getNMSClass("TileEntitySkull").getMethod("setGameProfile", GameProfile.class);
+                setGameProfile = ReflectionUtils.getNetMinecraftClass("world.level.block.entity.TileEntitySkull")
+                    .getMethod("setGameProfile", GameProfile.class);
 
-            Class<?> blockPosition = ReflectionUtils.getNMSClass("BlockPosition");
-            newPosition = ReflectionUtils.getConstructor(blockPosition, int.class, int.class, int.class);
-            getTileEntity = ReflectionUtils.getNMSClass("WorldServer").getMethod("getTileEntity", blockPosition);
+                Class<?> blockPosition = ReflectionUtils.getNetMinecraftClass("core.BlockPosition");
+                System.out.println(blockPosition);
+                newPosition = ReflectionUtils.getConstructor(blockPosition, int.class, int.class, int.class);
+                getTileEntity = ReflectionUtils.getNMSClass("level.WorldServer").getMethod("getTileEntity", blockPosition);
+            } else {
+                handle = ReflectionUtils.getOBCClass("CraftWorld").getMethod("getHandle");
+
+                setGameProfile = ReflectionUtils.getNMSClass("TileEntitySkull").getMethod("setGameProfile", GameProfile.class);
+
+                Class<?> blockPosition = ReflectionUtils.getNMSClass("BlockPosition");
+                newPosition = ReflectionUtils.getConstructor(blockPosition, int.class, int.class, int.class);
+                getTileEntity = ReflectionUtils.getNMSClass("WorldServer").getMethod("getTileEntity", blockPosition);
+            }
         } catch (NoSuchMethodException | SecurityException | ClassNotFoundException e) {
             System.err.println("Perhaps you forgot to shade CS-CoreLib's \"reflection\" package?");
             e.printStackTrace();


### PR DESCRIPTION
This PR adds in 1.17 support. It only targets the reflection code as that is all that broke. Classes are all now mapped in Spigot (yay!) however this means that they have moved. Alongside this, they are no longer mapped under `v1_{VER}_R1`.

This PR adds support for the 1.17+ strucutre while still keeping support for 1.16 and below.

**This will need to be merged and a version released before Slimefun/Slimefun4#X**