### PR TITLE
Resolve getBoolean overflow

### DIFF
--- a/src/main/java/io/github/thebusybiscuit/cscorelib2/data/PersistentDataAPI.java
+++ b/src/main/java/io/github/thebusybiscuit/cscorelib2/data/PersistentDataAPI.java
@@ -377,7 +377,8 @@ public final class PersistentDataAPI {
      * @return An Optional describing the result
      */
     public static Optional<Boolean> getOptionalBoolean(PersistentDataHolder holder, NamespacedKey key) {
-        return !hasBoolean(holder, key) ? Optional.empty() : Optional.of(getBoolean(holder, key));
+        final Byte b = holder.getPersistentDataContainer().get(key, PersistentDataType.BYTE);
+        return b == null ? Optional.empty() : Optional.of(b == 1);
     }
 
     /**


### PR DESCRIPTION
PersistentDataApi#getBoolean calls PersistentDataApi#getOptionalBoolean which calls PersistentDataApi#getBoolean causing an overflow.